### PR TITLE
Add command to view ConcertContacts

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddConcertContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddConcertContactCommand.java
@@ -72,7 +72,7 @@ public class AddConcertContactCommand extends Command {
 
         model.addConcertContact(linkedPerson);
         return new CommandResult(String.format(MESSAGE_LINK_PERSON_SUCCESS, Messages.format(personToLink),
-                Messages.format(concert)));
+                Messages.format(concert)), false, false, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddConcertContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddConcertContactCommand.java
@@ -72,7 +72,7 @@ public class AddConcertContactCommand extends Command {
 
         model.addConcertContact(linkedPerson);
         return new CommandResult(String.format(MESSAGE_LINK_PERSON_SUCCESS, Messages.format(personToLink),
-                Messages.format(concert)), false, false, true);
+                Messages.format(concert)));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -70,12 +70,13 @@ public class CommandResult {
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit;
+                && exit == otherCommandResult.exit
+                && showConcertContacts == otherCommandResult.showConcertContacts;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit);
+        return Objects.hash(feedbackToUser, showHelp, exit, showConcertContacts);
     }
 
     @Override
@@ -84,6 +85,7 @@ public class CommandResult {
                 .add("feedbackToUser", feedbackToUser)
                 .add("showHelp", showHelp)
                 .add("exit", exit)
+                .add("showConcertContacts", showConcertContacts)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -19,13 +19,17 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    /** List of concert contacts should be shown to the user. */
+    private final boolean showConcertContacts;
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean showConcertContacts) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
+        this.showConcertContacts = showConcertContacts;
     }
 
     /**
@@ -33,7 +37,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false);
+        this(feedbackToUser, false, false, false);
     }
 
     public String getFeedbackToUser() {
@@ -46,6 +50,10 @@ public class CommandResult {
 
     public boolean isExit() {
         return exit;
+    }
+
+    public boolean isShowConcertContacts() {
+        return showConcertContacts;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteConcertContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteConcertContactCommand.java
@@ -22,21 +22,21 @@ public class DeleteConcertContactCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: PERSONINDEX (must be a positive integer) "
-            + PREFIX_CONCERT + "CONCERTINDEX (must be a positive integer)\n"
+            + "Parameters: PERSON_INDEX (must be a positive integer) "
+            + PREFIX_CONCERT + "CONCERT_INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_CONCERT + "2";
 
     public static final String MESSAGE_DELETE_CONCERT_CONTACT_SUCCESS = "Deleted Person: %1$s from Concert: %1$s";
 
-    private final Index concertIndex;
-    private final Index personIndex;
+    private final Index indexC;
+    private final Index indexP;
 
     /**
      * Creates a DeleteConcertContactCommand to delete the specified {@code Person} from the specifed {@code Concert}.
      */
-    public DeleteConcertContactCommand(Index personIndex, Index concertIndex) {
-        this.personIndex = personIndex;
-        this.concertIndex = concertIndex;
+    public DeleteConcertContactCommand(Index indexP, Index indexC) {
+        this.indexP = indexP;
+        this.indexC = indexC;
     }
 
     @Override
@@ -45,16 +45,16 @@ public class DeleteConcertContactCommand extends Command {
         List<Person> lastShownPersonList = model.getFilteredPersonList();
         List<Concert> lastShownConcertList = model.getFilteredConcertList();
 
-        if (personIndex.getZeroBased() >= lastShownPersonList.size()) {
+        if (indexP.getZeroBased() >= lastShownPersonList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        if (concertIndex.getZeroBased() >= lastShownConcertList.size()) {
+        if (indexC.getZeroBased() >= lastShownConcertList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CONCERT_DISPLAYED_INDEX);
         }
 
-        Concert concertToEdit = lastShownConcertList.get(concertIndex.getZeroBased());
-        Person personToDelete = lastShownPersonList.get(personIndex.getZeroBased());
+        Concert concertToEdit = lastShownConcertList.get(indexC.getZeroBased());
+        Person personToDelete = lastShownPersonList.get(indexP.getZeroBased());
 
         if (!model.hasConcertContact(personToDelete, concertToEdit)) {
             throw new CommandException(Messages.MESSAGE_INVALID_CONCERT_CONTACT);
@@ -77,16 +77,16 @@ public class DeleteConcertContactCommand extends Command {
         }
 
         DeleteConcertContactCommand otherDeleteConcertContactCommand = (DeleteConcertContactCommand) other;
-        boolean sameConcertIndex = concertIndex.equals(otherDeleteConcertContactCommand.concertIndex);
-        boolean samePersonIndex = personIndex.equals(otherDeleteConcertContactCommand.personIndex);
+        boolean sameConcertIndex = indexC.equals(otherDeleteConcertContactCommand.indexC);
+        boolean samePersonIndex = indexP.equals(otherDeleteConcertContactCommand.indexP);
         return samePersonIndex && sameConcertIndex;
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("indexP", personIndex)
-                .add("indexC", concertIndex)
+                .add("indexP", indexP)
+                .add("indexC", indexC)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteConcertContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteConcertContactCommand.java
@@ -62,8 +62,7 @@ public class DeleteConcertContactCommand extends Command {
 
         model.deleteConcertContact(personToDelete, concertToEdit);
         return new CommandResult(String.format(MESSAGE_DELETE_CONCERT_CONTACT_SUCCESS,
-                Messages.format(personToDelete), Messages.format(concertToEdit)),
-                false, false, true);
+                Messages.format(personToDelete), Messages.format(concertToEdit)));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteConcertContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteConcertContactCommand.java
@@ -62,7 +62,8 @@ public class DeleteConcertContactCommand extends Command {
 
         model.deleteConcertContact(personToDelete, concertToEdit);
         return new CommandResult(String.format(MESSAGE_DELETE_CONCERT_CONTACT_SUCCESS,
-                Messages.format(personToDelete), Messages.format(concertToEdit)));
+                Messages.format(personToDelete), Messages.format(concertToEdit)),
+                false, false, true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListConcertContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListConcertContactCommand.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CONCERT_CONTACTS;
+
+import seedu.address.model.Model;
+
+/**
+ * Lists all concert contacts in the address book to the user.
+ */
+public class ListConcertContactCommand extends Command {
+
+    public static final String COMMAND_WORD = "listcc";
+
+    public static final String MESSAGE_SUCCESS = "Listed all concert contacts";
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredConcertContactList(PREDICATE_SHOW_ALL_CONCERT_CONTACTS);
+        return new CommandResult(MESSAGE_SUCCESS, false, false, true);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -23,6 +23,7 @@ import seedu.address.logic.commands.FindPersonCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListConcertCommand;
+import seedu.address.logic.commands.ListConcertContactCommand;
 import seedu.address.logic.commands.ListPersonCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -89,6 +90,9 @@ public class AddressBookParser {
 
         case ListPersonCommand.COMMAND_WORD:
             return new ListPersonCommand();
+
+        case ListConcertContactCommand.COMMAND_WORD:
+            return new ListConcertContactCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -202,6 +202,22 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
+     * Shows the list of {@code ConcertContact}.
+     *
+     */
+    public void handleShowConcertContactView() {
+        concertContactListContainer.visibleProperty().setValue(true);
+    }
+
+    /**
+     * Hides the list of {@code ConcertContact}.
+     *
+     */
+    public void handleHideConcertContactView() {
+        concertContactListContainer.visibleProperty().setValue(false);
+    }
+
+    /**
      * Executes the command and returns the result.
      *
      * @see seedu.address.logic.Logic#execute(String)
@@ -218,6 +234,12 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isExit()) {
                 handleExit();
+            }
+
+            if (commandResult.isShowConcertContacts()) {
+                handleShowConcertContactView();
+            } else {
+                handleHideConcertContactView();
             }
 
             return commandResult;

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -14,7 +14,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -29,10 +29,10 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false)));
     }
 
     @Test
@@ -46,10 +46,10 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false).hashCode());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -14,7 +14,8 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback",
+                false, false, false)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -29,10 +30,16 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback",
+                true, false, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback",
+                false, true, false)));
+
+        // different showConcertContacts value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback",
+                false, false, true)));
     }
 
     @Test
@@ -46,10 +53,16 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback",
+                true, false, false).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback",
+                false, true, false).hashCode());
+
+        // different showConcertContacts value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback",
+                false, false, true).hashCode());
     }
 
     @Test
@@ -57,7 +70,8 @@ public class CommandResultTest {
         CommandResult commandResult = new CommandResult("feedback");
         String expected = CommandResult.class.getCanonicalName() + "{feedbackToUser="
                 + commandResult.getFeedbackToUser() + ", showHelp=" + commandResult.isShowHelp()
-                + ", exit=" + commandResult.isExit() + "}";
+                + ", exit=" + commandResult.isExit() + ", showConcertContacts=" + commandResult.isShowConcertContacts()
+                + "}";
         assertEquals(expected, commandResult.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -21,6 +21,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.commons.NameContainsKeywordsPredicate;
 import seedu.address.model.concert.Concert;
+import seedu.address.model.concert.ConcertContact;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
@@ -161,5 +162,18 @@ public class CommandTestUtil {
         model.updateFilteredConcertList(v -> v.equals(concert));
 
         assertEquals(1, model.getFilteredConcertList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the concert contact at the given
+     * {@code targetIndex} in the {@code model}'s address book.
+     */
+    public static void showConcertContactAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredConcertContactList().size());
+
+        ConcertContact concertContact = model.getFilteredConcertContactList().get(targetIndex.getZeroBased());
+        model.updateFilteredConcertContactList(v -> v.equals(concertContact));
+
+        assertEquals(1, model.getFilteredConcertContactList().size());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -14,7 +14,7 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -14,7 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListConcertContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListConcertContactCommandTest.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showConcertContactAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBookConcertContacts;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CONCERTCONTACT;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListConcertContactCommand.
+ */
+public class ListConcertContactCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBookConcertContacts(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        CommandResult expectedCommandResult = new CommandResult(ListConcertContactCommand.MESSAGE_SUCCESS,
+                false, false, true);
+        assertCommandSuccess(new ListConcertContactCommand(), model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsFiltered_showsEverything() {
+        CommandResult expectedCommandResult = new CommandResult(ListConcertContactCommand.MESSAGE_SUCCESS,
+                false, false, true);
+        showConcertContactAtIndex(model, INDEX_FIRST_CONCERTCONTACT);
+        assertCommandSuccess(new ListConcertContactCommand(), model, expectedCommandResult, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -31,6 +31,7 @@ import seedu.address.logic.commands.FindPersonCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListConcertCommand;
+import seedu.address.logic.commands.ListConcertContactCommand;
 import seedu.address.logic.commands.ListPersonCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.commons.NameContainsKeywordsPredicate;
@@ -155,6 +156,13 @@ public class AddressBookParserTest {
     public void parseCommand_listPerson() throws Exception {
         assertTrue(parser.parseCommand(ListPersonCommand.COMMAND_WORD) instanceof ListPersonCommand);
         assertTrue(parser.parseCommand(ListPersonCommand.COMMAND_WORD + " 3") instanceof ListPersonCommand);
+    }
+
+    @Test
+    public void parseCommand_listConcertContact() throws Exception {
+        assertTrue(parser.parseCommand(ListConcertContactCommand.COMMAND_WORD) instanceof ListConcertContactCommand);
+        assertTrue(parser.parseCommand(ListConcertContactCommand.COMMAND_WORD + " 3")
+                instanceof ListConcertContactCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -11,4 +11,6 @@ public class TypicalIndexes {
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
     public static final Index INDEX_FIRST_CONCERT = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_CONCERT = Index.fromOneBased(2);
+    public static final Index INDEX_FIRST_CONCERTCONTACT = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_CONCERTCONTACT = Index.fromOneBased(2);
 }


### PR DESCRIPTION
In the current implementation, only `listcc` command will switch to the display for concertContacts.
So `addcc`, `deletecc`, will not switch to the display for concertContacts.

I felt this way made sense so I implemented it like that. If it's determined that `addcc` and `deletecc` should switch to the CC display, I can change it tomorrow, it should be quite a quick fix. Just need to change the `commandResult` returned to have true for the `showConcertContacts` boolean flag(similar to `showHelp` and `exit`).

Resolve #100