### PR TITLE
Update person duplicate handling

### DIFF
--- a/src/main/java/seedu/address/model/commons/Name.java
+++ b/src/main/java/seedu/address/model/commons/Name.java
@@ -56,7 +56,7 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+        return fullName.equalsIgnoreCase(otherName.fullName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -68,7 +68,7 @@ public class Email {
         }
 
         Email otherEmail = (Email) other;
-        return value.equals(otherEmail.value);
+        return value.equalsIgnoreCase(otherEmail.value);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -72,7 +72,7 @@ public class Person implements NamedObject {
     }
 
     /**
-     * Returns true if both persons have the same name and same email.
+     * Returns true if both persons have the same name, phone and email.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {
@@ -82,6 +82,7 @@ public class Person implements NamedObject {
 
         return otherPerson != null
                 && otherPerson.getName().equals(getName())
+                && otherPerson.getPhone().equals(getPhone())
                 && otherPerson.getEmail().equals(getEmail());
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -72,7 +72,7 @@ public class Person implements NamedObject {
     }
 
     /**
-     * Returns true if both persons have the same name.
+     * Returns true if both persons have the same name and same email.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {
@@ -81,7 +81,8 @@ public class Person implements NamedObject {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && otherPerson.getName().equals(getName())
+                && otherPerson.getEmail().equals(getEmail());
     }
 
     /**

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -11,7 +11,7 @@
     {
       "name": "Alice Pauline",
       "phone": "94351253",
-      "email": "pauline@example.com",
+      "email": "alice@example.com",
       "address": "4th street",
       "role": "artist"
     }

--- a/src/test/java/seedu/address/model/commons/NameTest.java
+++ b/src/test/java/seedu/address/model/commons/NameTest.java
@@ -45,6 +45,9 @@ public class NameTest {
         // same values -> returns true
         assertTrue(name.equals(new Name("Valid Name")));
 
+        // different casing -> returns true
+        assertTrue(name.equals(new Name("vAliD NAMe")));
+
         // same object -> returns true
         assertTrue(name.equals(name));
 

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -73,6 +73,9 @@ public class EmailTest {
         // same values -> returns true
         assertTrue(email.equals(new Email("valid@email")));
 
+        // different casing -> returns true
+        assertTrue(email.equals(new Email("vAlId@eMAIl")));
+
         // same object -> returns true
         assertTrue(email.equals(email));
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -32,9 +32,8 @@ public class PersonTest {
         // null -> returns false
         assertFalse(ALICE.isSamePerson(null));
 
-        // same name, same email, all other attributes different -> returns true
+        // same name, phone, email, all other attributes different -> returns true
         Person editedAlice = new PersonBuilder(ALICE)
-                .withPhone(VALID_PHONE_BOB)
                 .withAddress(VALID_ADDRESS_BOB)
                 .withTags(VALID_TAG_HUSBAND)
                 .build();
@@ -48,13 +47,13 @@ public class PersonTest {
         editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
-        Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        // different phone, all other attributes same -> returns false
+        editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
+        assertFalse(ALICE.isSamePerson(editedAlice));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
+        Person editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
         assertFalse(BOB.isSamePerson(editedBob));
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -32,13 +32,20 @@ public class PersonTest {
         // null -> returns false
         assertFalse(ALICE.isSamePerson(null));
 
-        // same name, all other attributes different -> returns true
-        Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
+        // same name, same email, all other attributes different -> returns true
+        Person editedAlice = new PersonBuilder(ALICE)
+                .withPhone(VALID_PHONE_BOB)
+                .withAddress(VALID_ADDRESS_BOB)
+                .withTags(VALID_TAG_HUSBAND)
+                .build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        assertFalse(ALICE.isSamePerson(editedAlice));
+
+        // different email, all other attributes same -> returns false
+        editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
         // name differs in case, all other attributes same -> returns false


### PR DESCRIPTION
Fixes #16 

The previous implementation of isSamePerson checks only the equality of the name field. However, in reality, it is highly likely that there are multiple people with the same name. 

Hence, the current implementation of isSamePerson includes the equality of both the name and email fields.